### PR TITLE
Mistake in Coastline FCode

### DIFF
--- a/R/prep_nhdplus.R
+++ b/R/prep_nhdplus.R
@@ -137,7 +137,7 @@ prepare_nhdplus <- function(flines,
 
 filter_coastal <- function(flines) {
   if("FCODE" %in% names(flines)) {
-    flines <- filter(flines, (FCODE != 566600))
+    flines <- filter(flines, (FCODE != 56600))
   } else if("FTYPE" %in% names(flines)) {
     flines <- filter(flines, (FTYPE != "Coastline" | FTYPE != 566))
   } else {


### PR DESCRIPTION
FCode for [coastline](https://nhd.usgs.gov/userGuide/Robohelpfiles/NHD_User_Guide/Feature_Catalog/Hydrography_Dataset/Complete_FCode_List.htm) is 56600.