### PR TITLE
fix status messaging in get_streamorder

### DIFF
--- a/R/get_codes.R
+++ b/R/get_codes.R
@@ -4,7 +4,7 @@
 #' maximum upstream order then the downstream flowpath is assigned the maximum
 #' upstream order plus one. Otherwise it is assigned the max upstream order.
 #' @param x data.frame with dendritic ID and toID columns.
-#' @param status logical emit progress update messages?
+#' @param status logical show progress update messages?
 #' @return numeric stream order in same order as input
 #' @importFrom dplyr left_join select
 #' @export
@@ -23,7 +23,7 @@
 #'
 #' plot(sf::st_geometry(walker_flowline), lwd = walker_flowline$order, col = "blue")
 #'
-get_streamorder <- function(x, status = FALSE) {
+get_streamorder <- function(x, status = TRUE) {
   check_names(x, "get_streamorder")
 
   o_sort <- select(x, .data$ID)
@@ -60,7 +60,7 @@ get_streamorder <- function(x, status = FALSE) {
       }
     }
 
-    if(i %% 1000 == 0) message(paste("ID", i, "of", length(ID)))
+    if(i %% 1000 == 0 & status) message(paste("ID", i, "of", length(ID)))
 
   }
 

--- a/man/get_streamorder.Rd
+++ b/man/get_streamorder.Rd
@@ -4,12 +4,12 @@
 \alias{get_streamorder}
 \title{Get Streamorder}
 \usage{
-get_streamorder(x, status = FALSE)
+get_streamorder(x, status = TRUE)
 }
 \arguments{
 \item{x}{data.frame with dendritic ID and toID columns.}
 
-\item{status}{logical emit progress update messages?}
+\item{status}{logical show progress update messages?}
 }
 \value{
 numeric stream order in same order as input


### PR DESCRIPTION
Hi @dblodgett-usgs,

This is a very minor change. In `get_streamorder()` the status messages were printing regardless of the `status` parameter. 

That should be fixed here.

Major change is that `TRUE` now indicates the status/progress be shown rather then omitted (more in line with other status parameters but feel free to revert 😄 ) 