### PR TITLE
export boundary datasets

### DIFF
--- a/R/boundary_datasets.R
+++ b/R/boundary_datasets.R
@@ -3,6 +3,7 @@
 #' @docType data
 #' @format An object of class \code{"sf"}
 #' @keywords data
+#' @export
 "vpu_boundaries"
 
 #' RPU Boundaries
@@ -10,4 +11,5 @@
 #' @docType data
 #' @format An object of class \code{"sf"}
 #' @keywords data
+#' @export
 "rpu_boundaries"


### PR DESCRIPTION
This addresses #280. `@export` was added to the VPU and RPU boundary datasets.

Thanks!