### PR TITLE
improve download_nhdplusv2 check7z behavior -- fixes #433

### DIFF
--- a/R/downloading_tools.R
+++ b/R/downloading_tools.R
@@ -179,7 +179,8 @@ download_nhdplusv2 <- function(outdir,
 
   if(!any(grepl("gdb", list.dirs(outdir)))) {
 
-    if(inherits("try-error", try(check7z()))) {
+    try_7z <- try(check7z())
+    if(inherits(try_7z, "try-error")) {
       message("couldn't find 7zip, won't try to extract data")
       message("check for data in: ", outdir)
       return(outdir)

--- a/R/downloading_tools.R
+++ b/R/downloading_tools.R
@@ -160,7 +160,7 @@ download_nhd_internal <- function(bucket, file_list_snip, prefix, nhd_dir, hu_li
 #' @export
 #' @examples
 #' \dontrun{
-#'   download_nhdplusV2("./data/nhd/")
+#'   download_nhdplusv2("./data/nhd/")
 #'
 #'   download_nhdplusv2(outdir = "./inst/",
 #'       url = paste0("https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/",
@@ -177,18 +177,24 @@ download_nhdplusv2 <- function(outdir,
   tryCatch({
   file <- downloader(outdir, url, "nhdplusV2", progress)
 
-  check7z()
+  if(!any(grepl("gdb", list.dirs(outdir)))) {
 
-  message("Extracting data ...")
+    if(inherits("try-error", try(check7z()))) {
+      message("couldn't find 7zip, won't try to extract data")
+      message("check for data in: ", outdir)
+      return(outdir)
+    }
 
-  ifelse(any(grepl("gdb", list.dirs(outdir))),
-         1,
-         system(paste0("7z -o", path.expand(outdir), " x ", file), intern = TRUE))
+    message("Extracting data ...")
+
+    system(paste0("7z -o", path.expand(outdir), " x ", file), intern = TRUE)
+
+  }
 
   path <- list.dirs(outdir)[grepl("gdb", list.dirs(outdir))]
   path <- path[grepl("NHDPlus", path)]
 
-  message(paste("NHDPlusV2 data extracted to:", path))
+  message(paste("NHDPlusV2 data available at:", path))
 
   return(invisible(path))
   }, error = function(e) {

--- a/man/download_nhdplusv2.Rd
+++ b/man/download_nhdplusv2.Rd
@@ -32,7 +32,7 @@ are available.
 }
 \examples{
 \dontrun{
-  download_nhdplusV2("./data/nhd/")
+  download_nhdplusv2("./data/nhd/")
 
   download_nhdplusv2(outdir = "./inst/",
       url = paste0("https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/",


### PR DESCRIPTION
@lkoenig-usgs -- this seem like it will do what you are after? 

With 7z available,  I see:

```r
> download_nhdplusv2("../../Data/nhdp/")
Downloading NHDPlusV21_NationalData_Seamless_Geodatabase_Lower48_07.7z
  |=========================================================================================================| 100%
Extracting data ...
NHDPlusV2 data available at: ../../Data/nhdp/NHDPlusNationalData/NHDPlusV21_National_Seamless_Flattened_Lower48.gdb
> download_nhdplusv2("../../Data/nhdp/")
Compressed NHDPLUSV2 file already exists ...
NHDPlusV2 data available at: ../../Data/nhdp/NHDPlusNationalData/NHDPlusV21_National_Seamless_Flattened_Lower48.gdb
```

I don't want to break my 7z install but it should now warn and return the path that the download was saved to if check7z fails.