### PR TITLE
Fixes for upcoming testthat 3.3.0 release

### DIFF
--- a/tests/testthat/test_01_get_nldi.R
+++ b/tests/testthat/test_01_get_nldi.R
@@ -31,7 +31,7 @@ test_that("navigation works", {
                        data_source = "nwissite",
                        distance_km = 1)
 
-  expect("sf" %in% class(nav$UM_nwissite), "expected an sf data.frame")
+  expect_true("sf" %in% class(nav$UM_nwissite))
 
   expect_true("sfc_POINT" %in% class(sf::st_geometry(nav$UM_nwissite)),
          "expected point response")
@@ -72,7 +72,7 @@ test_that("navigation works", {
                        data_source = "nwissite",
                        distance_km = 1)
 
-  expect("sf" %in% sapply(nav, class), "expected an sf data.frame")
+  expect_true("sf" %in% sapply(nav, class))
 
   # expect_equal(navigate_nldi(list(featureSource = "wqp",
   #                                 featureID = "TCEQMAIN-16638"),
@@ -92,7 +92,7 @@ test_that("basin works", {
 
   nav <- get_nldi_basin(nldi_feature = nldi_nwis)
 
-  expect("sf" %in% class(nav), "expected an sf data.frame")
+  expect_true("sf" %in% class(nav))
 
   expect_true("sfc_POLYGON" %in% class(sf::st_geometry(nav)),
          "expected polygon response")

--- a/tests/testthat/test_02_subset_extras.R
+++ b/tests/testthat/test_02_subset_extras.R
@@ -72,8 +72,8 @@ test_that("by rpu", {
   out <- subset_rpu(sample_flines, rpu = "07b")
 
   expect_equal(names(out), names(sample_flines))
-  expect(nrow(out), 267)
-  expect(nrow(subset_rpu(sample_flines, rpu = "07b",
+  expect_equal(nrow(out), 267)
+  expect_equal(nrow(subset_rpu(sample_flines, rpu = "07b",
                          run_make_standalone = TRUE)), 267)
 
   expect_equal(nrow(subset_vpu(sample_flines, vpu = "07")), 267)
@@ -85,8 +85,8 @@ test_that("by rpu", {
     prepare_nhdplus(sample_flines,
                     0, 0, 0, FALSE), by = "COMID"))
 
-  expect(nrow(subset_rpu(sample_flines, rpu = "07b")), 267)
-  expect(nrow(subset_rpu(sample_flines, rpu = "07b", run_make_standalone = FALSE)), 267)
+  expect_equal(nrow(subset_rpu(sample_flines, rpu = "07b")), 267)
+  expect_equal(nrow(subset_rpu(sample_flines, rpu = "07b", run_make_standalone = FALSE)), 267)
 
 })
 

--- a/tests/testthat/test_03_get_functions.R
+++ b/tests/testthat/test_03_get_functions.R
@@ -246,11 +246,11 @@ test_that("discover_nhdplus_id", {
 test_that("get_nwis", {
   testthat::skip_on_cran()
   areaSearch = get_nwis(AOI = area)
-  expect(nrow(areaSearch), 1)
+  expect_equal(nrow(areaSearch), 1)
   expect_equal(sf::st_crs(areaSearch)$epsg, 4326)
 
   areaSearch5070 = get_nwis(AOI = area, t_srs = 5070)
-  expect(nrow(areaSearch5070), 1)
+  expect_equal(nrow(areaSearch5070), 1)
   expect_equal(sf::st_crs(areaSearch5070)$epsg, 5070)
 
   expect_equal(areaSearch$site_no, areaSearch5070$site_no)

--- a/tests/testthat/test_calc_network.R
+++ b/tests/testthat/test_calc_network.R
@@ -30,8 +30,8 @@ test_that("total drainage area works", {
   catchment_area$totda <- new_da
   catchment_area$nhdptotda <- walker_flowline$TotDASqKM
 
-  expect(mean(abs(catchment_area$totda - catchment_area$nhdptotda)) < 1e-3, "drainage area not close enough")
-  expect(max(abs(catchment_area$totda - catchment_area$nhdptotda)) < 1e-2, "drainage area not close enough")
+  expect_true(mean(abs(catchment_area$totda - catchment_area$nhdptotda)) < 1e-3)
+  expect_true(max(abs(catchment_area$totda - catchment_area$nhdptotda)) < 1e-2)
 
   catchment_area$area[1] <- NA
 
@@ -52,8 +52,8 @@ test_that("arbolate sum works", {
   catchment_length$arb_sum <- arb_sum
   catchment_length$nhd_arb_sum <- walker_flowline$ArbolateSu
 
-  expect(mean(abs(catchment_length$arb_sum - catchment_length$nhd_arb_sum)) < 1e-3, "arbolate sum not close enough")
-  expect(max(abs(catchment_length$arb_sum - catchment_length$nhd_arb_sum)) < 1e-2, "arbolate sum not close enough")
+  expect_true(mean(abs(catchment_length$arb_sum - catchment_length$nhd_arb_sum)) < 1e-3)
+  expect_true(max(abs(catchment_length$arb_sum - catchment_length$nhd_arb_sum)) < 1e-2)
 })
 
 test_that("get_terminal", {

--- a/tests/testthat/test_get_nhdplus.R
+++ b/tests/testthat/test_get_nhdplus.R
@@ -10,13 +10,13 @@ test_that("get_nhdplus_byid", {
 
   catchmentsp <- nhdplusTools:::get_nhdplus_byid(comid_set, "catchmentsp")
 
-  expect("sf" %in% class(catchmentsp), "expected class sf")
+  expect_true("sf" %in% class(catchmentsp))
 
   expect_equal(nrow(catchmentsp), 5)
 
   nhdflowline_network <- nhdplusTools:::get_nhdplus_byid(comid_set, "nhdflowline_network")
 
-  expect("sf" %in% class(nhdflowline_network), "expected class sf")
+  expect_true("sf" %in% class(nhdflowline_network))
 
   expect_equal(nrow(nhdflowline_network), 5)
 
@@ -36,7 +36,7 @@ test_that("get_nhdplus_bybox", {
 
   for (layer in layers) {
     l <- nhdplusTools:::get_nhdplus_bybox(bbox, layer)
-    expect(nrow(l) > 1, "expected to get data")
+    expect_true(nrow(l) > 1)
     expect_true("sf" %in% class(l))
   }
 
@@ -70,5 +70,3 @@ test_that("downloaders run", {
   unlink(dir, recursive = T)
   expect_true(grepl("WBD_test.gdb", out))
 })
-
-

--- a/tests/testthat/test_get_nhdplushr.R
+++ b/tests/testthat/test_get_nhdplushr.R
@@ -44,7 +44,7 @@ test_that("get_nhdplushr layers and gpkg", {
 
   out <- get_nhdplushr(sw$wd, layers = NULL)
 
-  expect(length(names(out)), 7)
+  expect_equal(length(names(out)), 7)
 
   teardown_workdir(sw$wd)
 })

--- a/tests/testthat/test_get_path.R
+++ b/tests/testthat/test_get_path.R
@@ -44,7 +44,7 @@ test_that("calculate level path", {
     nhdp <- filter(walker_flowline, LevelPathI == nhdp_lp[lp])
     outlet_comid <- filter(nhdp, Hydroseq == min(Hydroseq))$COMID
     nhdt <- filter(test_flowline_out, outletID == outlet_comid)
-    expect(all(nhdp$COMID %in% nhdt$ID), paste("Mismatch in", nhdp_lp[lp],
+    expect_true(all(nhdp$COMID %in% nhdt$ID), info = paste("Mismatch in", nhdp_lp[lp],
                                                "level path from NHDPlus."))
   }
 


### PR DESCRIPTION
`expect()` is now stricter about checking it's inputs, revealing that you accidentally used it instead of `expect_true()` and `expect_equal()`.