### PR TITLE
Add StreamCat citation

### DIFF
--- a/R/get_vaa.R
+++ b/R/get_vaa.R
@@ -209,7 +209,10 @@ download_vaa <- function(path = get_vaa_path(updated_network), force = FALSE, up
 #'
 #' When \code{source = "streamcat"}, returns metric metadata from the EPA
 #' StreamCat dataset accessed via the \code{StreamCatTools} package (must be
-#' installed separately).
+#' installed separately):
+#' Weber, Marc H, Hill, Ryan A., Brookes, Allen F. 2024, StreamCatTools: Tools to 
+#' work with the StreamCat API within R and access the full suite of StreamCat and 
+#' LakeCat metrics, https://usepa.github.io/StreamCatTools
 #' @param search character string of length 1 to free search the metadata table.
 #' If no search term is provided the entire table is returned.
 #' @param source character \code{"usgs"} (default) or \code{"streamcat"}.


### PR DESCRIPTION
@dblodgett-usgs realize now you probably aren't updating pkgdown pages until a new release, so incorporation of your `streamcat` updates on pkgdown pages I mentioned in your #456 will all I assume happen then - but just put in this tiny PR to add citation for `StreamCatTools` analogous to what you have for when `source=usgs` in `get_catchment_characteristics`.